### PR TITLE
Add version key to manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Home Assistant integration for the go-eCharger (WIP)
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
+[![Validate with hassfest](https://github.com/cathiele/homeassistant-goecharger/actions/workflows/hassfest.yaml/badge.svg)](https://github.com/cathiele/homeassistant-goecharger/actions/workflows/hassfest.yaml)
 
 Integration for Homeassistant to view and Control the go-eCharger for electric Vehicles via the local ip-interface.
 

--- a/custom_components/goecharger/manifest.json
+++ b/custom_components/goecharger/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "goecharger",
     "name": "go-eCharger",
+    "version": "0.13.0",
     "documentation": "https://github.com/cathiele/homeassistant-goecharger",
     "dependencies": [],
     "codeowners": ["@cathiele"],


### PR DESCRIPTION
Added version key to manifest.json to fix this warning in the logs:

```
[homeassistant.loader] No 'version' key in the manifest file for custom integration 'goecharger'. This will not be allowed in a future version of Home Assistant. Please report this to the maintainer of 'goecharger'
```

This will fix your failing github action for hassfest as well, so I added the hassfest badge to the README.

I set the version in manifest.json to 0.13.0 which lets you draft a new release with this version so it shows up in HACS.